### PR TITLE
I have Added Contact Information Section in Footer with Phone and Email Links

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -220,8 +220,16 @@
     </div>
 
     <footer>
-      <p>&copy; 2025 StudySit. All rights reserved.</p>
-    </footer>
+      <footer>
+  <p style="color:#10b981; margin:5px 0;">
+    Phone: <a href="tel:+911234567890" style="color:#10b981; text-decoration:none;">+91-1234567890</a> |
+    <br>
+    Email: <a href="mailto:contact@studysit.com" style="color:#10b981; text-decoration:none;">contact@studysit.com</a>
+  </p>
+  <p>&copy; 2025 StudySit. All rights reserved.</p>
+</footer>
+
+      
 
     <script>
       const form = document.querySelector(".contact-form form");


### PR DESCRIPTION
I have updated the Contact Us page of the  project by adding a dedicated contact information section in the footer. This section includes:

A clickable phone number (tel: link)

A clickable email address (mailto: link)

Styling consistent with the website theme (green color #10b981)

The updated footer now displays the contact details above the copyright notice while maintaining responsiveness and accessibility.

I would like to raise this as an issue to track the addition and gather feedback on improving design, accessibility, or consistency with the rest of the site