### PR TITLE
Added GSSoC 2025 banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/GirlScriptSummerOfCode/GSSoC-2025/main/assets/banner.png" alt="GSSoC 2025" width="90%">
+  <img src="https://raw.githubusercontent.com/girlscript/gssoc-assets/main/Logos/GS_logo_White.png#gh-dark-mode-only" alt="GSSoC 2025" width="90%">
 </p>
 
 Quick overview

--- a/signup.html
+++ b/signup.html
@@ -170,6 +170,7 @@
 </head>
 <body class="bg-study-bg text-study-text">
 
+
 <!-- HEADER & NAVIGATION -->
 <header class="fixed top-0 w-full bg-study-bg/95 backdrop-blur-sm shadow-sm transition-all duration-300 z-50">
   <nav class="container mx-auto px-6 py-4 flex justify-between items-center">


### PR DESCRIPTION
This PR adds a GSSoC 2025 banner to the top of the README to highlight the project’s participation in the program and enhance visibility.

Changes Made:
- Added official GSSoC 2025 banner to README.md
- Kept alignment centered for a clean and professional look

Fixes: #98